### PR TITLE
Rocket and Rover fuel fixes

### DIFF
--- a/common/src/main/java/com/st0x0ef/stellaris/client/screens/RocketScreen.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/client/screens/RocketScreen.java
@@ -37,7 +37,7 @@ public class RocketScreen extends AbstractContainerScreen<RocketMenu> {
             return;
         }
 
-        fuelGauge = new GaugeWidget(leftPos + 51, topPos + 27, 12, 46, Component.translatable("stellaris.screen.fuel"), rocket.getRocketComponent().getMotorUpgrade().getFluidTexture(), GUISprites.FLUID_TANK_OVERLAY, rocket.getTankCapacity(), GaugeWidget.Direction4.DOWN_UP);
+        fuelGauge = new GaugeWidget(leftPos + 51, topPos + 27, 12, 46, Component.translatable("stellaris.screen.fuel"), rocket.getRocketComponent().getMotorUpgrade().getFuelType().getFuelTexture(), GUISprites.FLUID_TANK_OVERLAY, rocket.getTankCapacity(), GaugeWidget.Direction4.DOWN_UP);
         addRenderableWidget(fuelGauge);
     }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/client/screens/RocketScreen.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/client/screens/RocketScreen.java
@@ -37,7 +37,7 @@ public class RocketScreen extends AbstractContainerScreen<RocketMenu> {
             return;
         }
 
-        fuelGauge = new GaugeWidget(leftPos + 51, topPos + 27, 12, 46, Component.translatable("stellaris.screen.fuel"), rocket.getRocketComponent().getMotorUpgrade().getFuelType().getFuelTexture(), GUISprites.FLUID_TANK_OVERLAY, rocket.getTankCapacity(), GaugeWidget.Direction4.DOWN_UP);
+        fuelGauge = new GaugeWidget(leftPos + 51, topPos + 27, 12, 46, Component.translatable("stellaris.screen.fuel"), rocket.getRocketComponent().getFuelType().getFuelTexture(), GUISprites.FLUID_TANK_OVERLAY, rocket.getTankCapacity(), GaugeWidget.Direction4.DOWN_UP);
         addRenderableWidget(fuelGauge);
     }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/client/screens/RoverScreen.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/client/screens/RoverScreen.java
@@ -36,7 +36,7 @@ public class RoverScreen  extends AbstractContainerScreen<RoverMenu> {
             return;
         }
 
-        fuelGauge = new GaugeWidget(leftPos + 51, topPos + 27, 12, 46, Component.translatable("stellaris.screen.fuel"), rover.getRoverComponent().getMotorUpgrade().getFuelType().getFuelTexture(), GUISprites.FLUID_TANK_OVERLAY, rover.getRoverComponent().getTankCapacity(), GaugeWidget.Direction4.DOWN_UP);
+        fuelGauge = new GaugeWidget(leftPos + 51, topPos + 27, 12, 46, Component.translatable("stellaris.screen.fuel"), rover.getRoverComponent().getFuelType().getFuelTexture(), GUISprites.FLUID_TANK_OVERLAY, rover.getRoverComponent().getTankCapacity(), GaugeWidget.Direction4.DOWN_UP);
         addRenderableWidget(fuelGauge);
     }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/client/screens/RoverScreen.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/client/screens/RoverScreen.java
@@ -36,7 +36,7 @@ public class RoverScreen  extends AbstractContainerScreen<RoverMenu> {
             return;
         }
 
-        fuelGauge = new GaugeWidget(leftPos + 51, topPos + 27, 12, 46, Component.translatable("stellaris.screen.fuel"), rover.getRoverComponent().getMotorUpgrade().getFluidTexture(), GUISprites.FLUID_TANK_OVERLAY, rover.getRoverComponent().getTankCapacity(), GaugeWidget.Direction4.DOWN_UP);
+        fuelGauge = new GaugeWidget(leftPos + 51, topPos + 27, 12, 46, Component.translatable("stellaris.screen.fuel"), rover.getRoverComponent().getMotorUpgrade().getFuelType().getFuelTexture(), GUISprites.FLUID_TANK_OVERLAY, rover.getRoverComponent().getTankCapacity(), GaugeWidget.Direction4.DOWN_UP);
         addRenderableWidget(fuelGauge);
     }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
@@ -50,7 +50,7 @@ public record RocketComponent(String skin, RocketModel model, String fuelType, i
     }
 
     public MotorUpgrade getMotorUpgrade() {
-        return new MotorUpgrade(FuelType.Type.fromString(fuelType), fuelTexture);
+        return new MotorUpgrade(FuelType.Type.fromString(fuelType));
     }
 
     public TankUpgrade getTankUpgrade() {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
@@ -51,7 +51,7 @@ public record RocketComponent(String skin, RocketModel model, String fuelType, i
     }
 
     public MotorUpgrade getMotorUpgrade() {
-        return new MotorUpgrade(FuelType.Type.fromString(fuelType));
+        return new MotorUpgrade(this.getFuelType().getMotorType());
     }
 
     public FuelType.Type getFuelType() {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
@@ -53,6 +53,10 @@ public record RocketComponent(String skin, RocketModel model, String fuelType, i
         return new MotorUpgrade(FuelType.Type.fromString(fuelType));
     }
 
+    public FuelType.Type getFuelType() {
+        return FuelType.Type.fromString(fuelType);
+    }
+
     public TankUpgrade getTankUpgrade() {
         return new TankUpgrade(tankCapacity);
     }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
@@ -65,14 +65,9 @@ public record RocketComponent(String skin, RocketModel model, String fuelType, i
 
         //Workaround to allow rockets from previous versions with badly formed components to load
         //e.g "hydrogen_bucket" as fuel_type
+        Item item = FuelType.getItemBasedOnLoacation(ResourceLocation.parse(fuelType));
 
-        ResourceLocation itemLoc = ResourceLocation.tryParse(fuelType);
-        if (itemLoc == null) return FuelType.Type.FUEL;
-
-        Optional<Item> item = BuiltInRegistries.ITEM.getOptional(itemLoc);
-        if (item.isEmpty()) return FuelType.Type.FUEL;
-
-        type = FuelType.Type.getTypeBasedOnItem(item.get());
+        type = FuelType.Type.getTypeBasedOnItem(item);
         if (type != null) return type;
 
         return FuelType.Type.FUEL;

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
@@ -2,12 +2,9 @@ package com.st0x0ef.stellaris.common.data_components;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import com.st0x0ef.stellaris.Stellaris;
 import com.st0x0ef.stellaris.client.renderers.entities.vehicle.rocket.RocketModel;
-import com.st0x0ef.stellaris.common.registry.ItemsRegistry;
 import com.st0x0ef.stellaris.common.vehicle_upgrade.*;
 import io.netty.buffer.ByteBuf;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -15,7 +12,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 
 import java.io.Serializable;
-import java.util.Optional;
 
 public record RocketComponent(String skin, RocketModel model, String fuelType, int fuel, ResourceLocation fuelTexture, int tankCapacity) implements Serializable {
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
@@ -2,15 +2,20 @@ package com.st0x0ef.stellaris.common.data_components;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.st0x0ef.stellaris.Stellaris;
 import com.st0x0ef.stellaris.client.renderers.entities.vehicle.rocket.RocketModel;
+import com.st0x0ef.stellaris.common.registry.ItemsRegistry;
 import com.st0x0ef.stellaris.common.vehicle_upgrade.*;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 public record RocketComponent(String skin, RocketModel model, String fuelType, int fuel, ResourceLocation fuelTexture, int tankCapacity) implements Serializable {
 
@@ -55,7 +60,22 @@ public record RocketComponent(String skin, RocketModel model, String fuelType, i
     }
 
     public FuelType.Type getFuelType() {
-        return FuelType.Type.fromString(fuelType);
+        FuelType.Type type = FuelType.Type.fromString(fuelType);
+        if (type != null) return type;
+
+        //Workaround to allow rockets from previous versions with badly formed components to load
+        //e.g "hydrogen_bucket" as fuel_type
+
+        ResourceLocation itemLoc = ResourceLocation.tryParse(fuelType);
+        if (itemLoc == null) return FuelType.Type.FUEL;
+
+        Optional<Item> item = BuiltInRegistries.ITEM.getOptional(itemLoc);
+        if (item.isEmpty()) return FuelType.Type.FUEL;
+
+        type = FuelType.Type.getTypeBasedOnItem(item.get());
+        if (type != null) return type;
+
+        return FuelType.Type.FUEL;
     }
 
     public TankUpgrade getTankUpgrade() {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RocketComponent.java
@@ -29,8 +29,9 @@ public record RocketComponent(String skin, RocketModel model, String fuelType, i
         return fuel;
     }
 
+    @Deprecated
     public ResourceLocation getFuelTexture() {
-        return fuelTexture;
+        return this.getFuelType().getFuelTexture();
     }
 
     public ResourceLocation getSkin() {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
@@ -4,7 +4,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.st0x0ef.stellaris.common.vehicle_upgrade.*;
 import io.netty.buffer.ByteBuf;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -12,7 +11,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 
 import java.io.Serializable;
-import java.util.Optional;
 
 public record RoverComponent(String fuelType, int fuel, ResourceLocation fuelTexture, int tankCapacity, float speedModifier) implements Serializable {
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
@@ -33,7 +33,7 @@ public record RoverComponent(String fuelType, int fuel, ResourceLocation fuelTex
     }
 
     public MotorUpgrade getMotorUpgrade() {
-        return new MotorUpgrade(FuelType.Type.fromString(fuelType));
+        return new MotorUpgrade(this.getFuelType().getMotorType());
     }
 
     public FuelType.Type getFuelType() {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
@@ -45,14 +45,9 @@ public record RoverComponent(String fuelType, int fuel, ResourceLocation fuelTex
 
         //Workaround to allow rovers from previous versions with badly formed components to load
         //e.g "hydrogen_bucket" as fuel_type
+        Item item = FuelType.getItemBasedOnLoacation(ResourceLocation.parse(fuelType));
 
-        ResourceLocation itemLoc = ResourceLocation.tryParse(fuelType);
-        if (itemLoc == null) return FuelType.Type.FUEL;
-
-        Optional<Item> item = BuiltInRegistries.ITEM.getOptional(itemLoc);
-        if (item.isEmpty()) return FuelType.Type.FUEL;
-
-        type = FuelType.Type.getTypeBasedOnItem(item.get());
+        type = FuelType.Type.getTypeBasedOnItem(item);
         if (type != null) return type;
 
         return FuelType.Type.FUEL;

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
@@ -35,6 +35,10 @@ public record RoverComponent(String fuelType, int fuel, ResourceLocation fuelTex
         return new MotorUpgrade(FuelType.Type.fromString(fuelType));
     }
 
+    public FuelType.Type getFuelType() {
+        return FuelType.Type.fromString(fuelType);
+    }
+
     public TankUpgrade getTankUpgrade() {
         return new TankUpgrade(tankCapacity);
     }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
@@ -27,8 +27,9 @@ public record RoverComponent(String fuelType, int fuel, ResourceLocation fuelTex
         return fuel;
     }
 
+    @Deprecated
     public ResourceLocation getFuelTexture() {
-        return fuelTexture;
+        return this.getFuelType().getFuelTexture();
     }
 
     public MotorUpgrade getMotorUpgrade() {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
@@ -32,7 +32,7 @@ public record RoverComponent(String fuelType, int fuel, ResourceLocation fuelTex
     }
 
     public MotorUpgrade getMotorUpgrade() {
-        return new MotorUpgrade(FuelType.Type.fromString(fuelType), fuelTexture);
+        return new MotorUpgrade(FuelType.Type.fromString(fuelType));
     }
 
     public TankUpgrade getTankUpgrade() {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/data_components/RoverComponent.java
@@ -4,12 +4,15 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.st0x0ef.stellaris.common.vehicle_upgrade.*;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 public record RoverComponent(String fuelType, int fuel, ResourceLocation fuelTexture, int tankCapacity, float speedModifier) implements Serializable {
 
@@ -37,7 +40,22 @@ public record RoverComponent(String fuelType, int fuel, ResourceLocation fuelTex
     }
 
     public FuelType.Type getFuelType() {
-        return FuelType.Type.fromString(fuelType);
+        FuelType.Type type = FuelType.Type.fromString(fuelType);
+        if (type != null) return type;
+
+        //Workaround to allow rovers from previous versions with badly formed components to load
+        //e.g "hydrogen_bucket" as fuel_type
+
+        ResourceLocation itemLoc = ResourceLocation.tryParse(fuelType);
+        if (itemLoc == null) return FuelType.Type.FUEL;
+
+        Optional<Item> item = BuiltInRegistries.ITEM.getOptional(itemLoc);
+        if (item.isEmpty()) return FuelType.Type.FUEL;
+
+        type = FuelType.Type.getTypeBasedOnItem(item.get());
+        if (type != null) return type;
+
+        return FuelType.Type.FUEL;
     }
 
     public TankUpgrade getTankUpgrade() {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/IVehicleEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/IVehicleEntity.java
@@ -262,6 +262,9 @@ public abstract class IVehicleEntity extends Entity{
         return this.FUEL;
     }
 
+    public FuelType.Type getFuelType() {
+        return this.FUEL_TYPE;
+    }
 
     @Override
     public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity entity) {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/IVehicleEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/IVehicleEntity.java
@@ -1,5 +1,6 @@
 package com.st0x0ef.stellaris.common.entities.vehicles;
 
+import com.st0x0ef.stellaris.common.vehicle_upgrade.FuelType;
 import dev.architectury.networking.NetworkManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.Packet;
@@ -21,6 +22,8 @@ import net.minecraft.world.phys.Vec3;
 
 public abstract class IVehicleEntity extends Entity{
     public int FUEL;
+
+    public FuelType.Type FUEL_TYPE;
 
     private int lerpSteps;
     private double lerpX;

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/IVehicleEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/IVehicleEntity.java
@@ -23,7 +23,7 @@ import net.minecraft.world.phys.Vec3;
 public abstract class IVehicleEntity extends Entity{
     public int FUEL;
 
-    public FuelType.Type FUEL_TYPE;
+    public FuelType.Type FUEL_TYPE = FuelType.Type.FUEL;
 
     private int lerpSteps;
     private double lerpX;

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -517,7 +517,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
         FuelType.Type itemType = FuelType.Type.getTypeBasedOnItem(item);
         FuelType.Type motorType = MOTOR_UPGRADE.getFuelType();
 
-        if (motorType.acceptsType(itemType)) {
+        if (motorType == itemType.getMotorType()) {
             if (FUEL == 0) {
                 FUEL_TYPE = itemType;
             }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -63,8 +63,6 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
     public MotorUpgrade MOTOR_UPGRADE;
     public TankUpgrade TANK_UPGRADE;
 
-    private Item currentFuelItem;
-
     protected SimpleContainer inventory;
 
     private RocketComponent rocketComponent;
@@ -95,8 +93,9 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
         this.START_TIMER = 0;
         this.FUEL = 0;
 
-        this.currentFuelItem = ItemsRegistry.FUEL_BUCKET.get();
-        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), currentFuelItem.toString(), FUEL, MOTOR_UPGRADE.getFuelType().getFuelTexture(), TANK_UPGRADE.getTankCapacity());
+        this.FUEL_TYPE = FuelType.Type.FUEL;
+
+        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), FUEL_TYPE.getSerializedName(), FUEL, MOTOR_UPGRADE.getFuelType().getFuelTexture(), TANK_UPGRADE.getTankCapacity());
         this.inventory = new SimpleContainer(14);
     }
 
@@ -108,7 +107,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
         this.MOTOR_UPGRADE = rocketComponent.getMotorUpgrade();
         this.TANK_UPGRADE = rocketComponent.getTankUpgrade();
         this.FUEL = rocketComponent.getFuel();
-        this.currentFuelItem = FuelType.getItemBasedOnTypeName(rocketComponent.fuelType());
+        this.FUEL_TYPE = rocketComponent.getFuelType();
     }
 
     @Override
@@ -149,12 +148,8 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
         compound.put("InventoryCustom", this.inventory.createTag(registryAccess()));
         compound.putInt("fuel", FUEL);
 
-        if (FUEL != 0 && currentFuelItem != null) {
-            if (FuelType.Type.getTypeBasedOnItem(currentFuelItem) != null) {
-                compound.putString("currentFuelItemType", FuelType.Type.getTypeBasedOnItem(currentFuelItem).getSerializedName());
-            } else if (FuelType.Type.Radioactive.getTypeBasedOnItem(currentFuelItem) != null) {
-                compound.putString("currentFuelItemType", FuelType.Type.Radioactive.getTypeBasedOnItem(currentFuelItem).getSerializedName());
-            }
+        if (FUEL != 0) {
+            compound.putString("currentFuelItemType", FUEL_TYPE.getSerializedName());
         }
 
         ListTag listTag = new ListTag();
@@ -178,7 +173,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
         FUEL = compound.getInt("fuel");
 
         if (FUEL != 0) {
-            currentFuelItem = FuelType.getItemBasedOnTypeName(compound.getString("currentFuelItemType"));
+            FUEL_TYPE = FuelType.Type.fromString(compound.getString("currentFuelItemType"));
         }
 
         ListTag listTag = compound.getList("Items", 10);
@@ -519,40 +514,31 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
             return false;
         }
 
-        if (MOTOR_UPGRADE.getFuelType().equals(FuelType.Type.RADIOACTIVE) && FuelType.Type.Radioactive.getTypeBasedOnItem(item) != null && canPutFuelBasedOnCurrentFuelItem(item)) {
-            FUEL += 1000;
-            if (FUEL > TANK_UPGRADE.getTankCapacity()) {
-                FUEL = TANK_UPGRADE.getTankCapacity();
+        FuelType.Type itemType = FuelType.Type.getTypeBasedOnItem(item);
+        FuelType.Type motorType = MOTOR_UPGRADE.getFuelType();
+
+        if (motorType.acceptsType(itemType)) {
+            if (FUEL == 0) {
+                FUEL_TYPE = itemType;
             }
 
-            inventory.removeItem(0, 1);
+            if (itemType == FUEL_TYPE) {
+                FUEL += 1000;
+                if (FUEL > TANK_UPGRADE.getTankCapacity()) {
+                    FUEL = TANK_UPGRADE.getTankCapacity();
+                }
 
-            return true;
-        }
+                ItemStack fuelItem = inventory.removeItem(0, 1);
 
-        if (FuelType.Type.getTypeBasedOnItem(item) == MOTOR_UPGRADE.getFuelType() && canPutFuelBasedOnCurrentFuelItem(item)) {
-            FUEL += 1000;
-            if (FUEL > TANK_UPGRADE.getTankCapacity()) {
-                FUEL = TANK_UPGRADE.getTankCapacity();
+                if (fuelItem.is(ItemsRegistry.FUEL_BUCKET.get()) || fuelItem.is(ItemsRegistry.HYDROGEN_BUCKET.get())) {
+                    inventory.setItem(1, new ItemStack(Items.BUCKET, inventory.getItem(1).getCount() + 1));
+                }
+
+                return true;
             }
-
-            if (inventory.removeItem(0, 1).is(ItemsRegistry.FUEL_BUCKET.get()) || inventory.removeItem(0, 1).is(ItemsRegistry.HYDROGEN_BUCKET.get())) {
-                inventory.setItem(1, new ItemStack(Items.BUCKET, inventory.getItem(1).getCount()+1));
-            }
-
-            return true;
         }
 
         return false;
-    }
-
-    private boolean canPutFuelBasedOnCurrentFuelItem(Item item) {
-        if (FUEL == 0) {
-            currentFuelItem = item;
-            return true;
-        }
-
-        return currentFuelItem == item;
     }
 
     private void openPlanetMenu(Player player) {
@@ -622,7 +608,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
     }
 
     public void syncRocketData(ServerPlayer player) {
-        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), currentFuelItem.toString(), FUEL, MOTOR_UPGRADE.getFuelType().getFuelTexture(), TANK_UPGRADE.getTankCapacity());
+        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), FUEL_TYPE.getSerializedName(), FUEL, MOTOR_UPGRADE.getFuelType().getFuelTexture(), TANK_UPGRADE.getTankCapacity());
         if (!level().isClientSide()) {
             NetworkManager.sendToPlayer(player, new SyncRocketComponentPacket(rocketComponent));
         }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -510,7 +510,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
 
     public boolean tryFillUpRocket(Item item) {
         if (this.level().isClientSide) return false;
-        if (FUEL == TANK_UPGRADE.getTankCapacity() || item == null) {
+        if (FUEL >= TANK_UPGRADE.getTankCapacity() || item == null) {
             return false;
         }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -95,7 +95,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
 
         this.FUEL_TYPE = FuelType.Type.FUEL;
 
-        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), FUEL_TYPE.getSerializedName(), FUEL, MOTOR_UPGRADE.getFuelType().getFuelTexture(), TANK_UPGRADE.getTankCapacity());
+        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), FUEL_TYPE.getSerializedName(), FUEL, FUEL_TYPE.getFuelTexture(), TANK_UPGRADE.getTankCapacity());
         this.inventory = new SimpleContainer(14);
     }
 
@@ -608,7 +608,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
     }
 
     public void syncRocketData(ServerPlayer player) {
-        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), FUEL_TYPE.getSerializedName(), FUEL, MOTOR_UPGRADE.getFuelType().getFuelTexture(), TANK_UPGRADE.getTankCapacity());
+        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), FUEL_TYPE.getSerializedName(), FUEL, FUEL_TYPE.getFuelTexture(), TANK_UPGRADE.getTankCapacity());
         if (!level().isClientSide()) {
             NetworkManager.sendToPlayer(player, new SyncRocketComponentPacket(rocketComponent));
         }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -96,7 +96,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
         this.FUEL = 0;
 
         this.currentFuelItem = ItemsRegistry.FUEL_BUCKET.get();
-        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), currentFuelItem.toString(), FUEL, MOTOR_UPGRADE.getFluidTexture(), TANK_UPGRADE.getTankCapacity());
+        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), currentFuelItem.toString(), FUEL, MOTOR_UPGRADE.getFuelType().getFuelTexture(), TANK_UPGRADE.getTankCapacity());
         this.inventory = new SimpleContainer(14);
     }
 
@@ -622,7 +622,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
     }
 
     public void syncRocketData(ServerPlayer player) {
-        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), currentFuelItem.toString(), FUEL, MOTOR_UPGRADE.getFluidTexture(), TANK_UPGRADE.getTankCapacity());
+        this.rocketComponent = new RocketComponent(SKIN_UPGRADE.getRocketSkinLocation().toString(), RocketModel.fromString(MODEL_UPGRADE.getModel().toString()), currentFuelItem.toString(), FUEL, MOTOR_UPGRADE.getFuelType().getFuelTexture(), TANK_UPGRADE.getTankCapacity());
         if (!level().isClientSide()) {
             NetworkManager.sendToPlayer(player, new SyncRocketComponentPacket(rocketComponent));
         }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -604,7 +604,7 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
     }
 
     public boolean canGoTo(Planet actual, Planet destination) {
-        return Mth.abs(actual.distanceFromEarth() - destination.distanceFromEarth()) <= FuelType.getMegametersTraveled(this.rocketComponent.fuel(), FuelType.getItemBasedOnLoacation(ResourceLocation.parse(this.rocketComponent.fuelType())));
+        return Mth.abs(actual.distanceFromEarth() - destination.distanceFromEarth()) <= FuelType.getMegametersTraveled(FUEL, FUEL_TYPE);
     }
 
     public void syncRocketData(ServerPlayer player) {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
@@ -54,7 +54,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
         this.speedUpgrade = SpeedUpgrade.getBasic();
         this.currentFuelItem = ItemsRegistry.FUEL_BUCKET.get();
         this.FUEL = 0;
-        this.roverComponent = new RoverComponent(currentFuelItem.toString(), FUEL, motorUpgrade.getFluidTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
+        this.roverComponent = new RoverComponent(currentFuelItem.toString(), FUEL, motorUpgrade.getFuelType().getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
     }
 
     public void setRoverComponent(RoverComponent roverComponent) {
@@ -267,7 +267,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
     }
 
     public void syncRocketData(ServerPlayer player) {
-        this.roverComponent = new RoverComponent(currentFuelItem.toString(), FUEL, motorUpgrade.getFluidTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
+        this.roverComponent = new RoverComponent(currentFuelItem.toString(), FUEL, motorUpgrade.getFuelType().getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
         if (!level().isClientSide()) {
             NetworkManager.sendToPlayer(player, new SyncRoverComponentPacket(roverComponent));
         }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
@@ -53,7 +53,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
         this.speedUpgrade = SpeedUpgrade.getBasic();
         this.FUEL = 0;
         this.FUEL_TYPE = FuelType.Type.FUEL;
-        this.roverComponent = new RoverComponent(FUEL_TYPE.getSerializedName(), FUEL, motorUpgrade.getFuelType().getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
+        this.roverComponent = new RoverComponent(FUEL_TYPE.getSerializedName(), FUEL, FUEL_TYPE.getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
     }
 
     public void setRoverComponent(RoverComponent roverComponent) {
@@ -257,7 +257,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
     }
 
     public void syncRocketData(ServerPlayer player) {
-        this.roverComponent = new RoverComponent(FUEL_TYPE.getSerializedName(), FUEL, motorUpgrade.getFuelType().getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
+        this.roverComponent = new RoverComponent(FUEL_TYPE.getSerializedName(), FUEL, FUEL_TYPE.getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
         if (!level().isClientSide()) {
             NetworkManager.sendToPlayer(player, new SyncRoverComponentPacket(roverComponent));
         }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
@@ -197,7 +197,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
 
     public boolean tryFillUpRover(Item item) {
         if (this.level().isClientSide) return false;
-        if (FUEL == tankUpgrade.getTankCapacity() || item == null) {
+        if (FUEL >= tankUpgrade.getTankCapacity() || item == null) {
             return false;
         }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
@@ -204,7 +204,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
         FuelType.Type itemType = FuelType.Type.getTypeBasedOnItem(item);
         FuelType.Type motorType = motorUpgrade.getFuelType();
 
-        if (motorType.acceptsType(itemType)) {
+        if (motorType == itemType.getMotorType()) {
             if (FUEL == 0) {
                 FUEL_TYPE = itemType;
             }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
@@ -40,7 +40,6 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
     public MotorUpgrade motorUpgrade;
     public TankUpgrade tankUpgrade;
     public SpeedUpgrade speedUpgrade;
-    private Item currentFuelItem;
     public final SimpleContainer inventory;
 
     public RoverComponent roverComponent;
@@ -52,9 +51,9 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
         this.motorUpgrade = MotorUpgrade.getBasic();
         this.tankUpgrade = TankUpgrade.getBasic();
         this.speedUpgrade = SpeedUpgrade.getBasic();
-        this.currentFuelItem = ItemsRegistry.FUEL_BUCKET.get();
         this.FUEL = 0;
-        this.roverComponent = new RoverComponent(currentFuelItem.toString(), FUEL, motorUpgrade.getFuelType().getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
+        this.FUEL_TYPE = FuelType.Type.FUEL;
+        this.roverComponent = new RoverComponent(FUEL_TYPE.getSerializedName(), FUEL, motorUpgrade.getFuelType().getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
     }
 
     public void setRoverComponent(RoverComponent roverComponent) {
@@ -64,7 +63,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
         this.tankUpgrade = roverComponent.getTankUpgrade();
         this.speedUpgrade = roverComponent.getSpeedUpgrade();
         this.FUEL = roverComponent.getFuel();
-        this.currentFuelItem = FuelType.getItemBasedOnTypeName(roverComponent.fuelType());
+        this.FUEL_TYPE = roverComponent.getFuelType();
     }
 
     @Override
@@ -202,40 +201,31 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
             return false;
         }
 
-        if (motorUpgrade.getFuelType().equals(FuelType.Type.RADIOACTIVE) && FuelType.Type.Radioactive.getTypeBasedOnItem(item) != null && canPutFuelBasedOnCurrentFuelItem(item)) {
-            FUEL += 1000;
-            if (FUEL > tankUpgrade.getTankCapacity()) {
-                FUEL = tankUpgrade.getTankCapacity();
+        FuelType.Type itemType = FuelType.Type.getTypeBasedOnItem(item);
+        FuelType.Type motorType = motorUpgrade.getFuelType();
+
+        if (motorType.acceptsType(itemType)) {
+            if (FUEL == 0) {
+                FUEL_TYPE = itemType;
             }
 
-            inventory.removeItem(0, 1);
+            if (itemType == FUEL_TYPE) {
+                FUEL += 1000;
+                if (FUEL > tankUpgrade.getTankCapacity()) {
+                    FUEL = tankUpgrade.getTankCapacity();
+                }
 
-            return true;
-        }
+                ItemStack fuelItem = inventory.removeItem(0, 1);
 
-        if (FuelType.Type.getTypeBasedOnItem(item) == motorUpgrade.getFuelType() && canPutFuelBasedOnCurrentFuelItem(item)) {
-            FUEL += 1000;
-            if (FUEL > tankUpgrade.getTankCapacity()) {
-                FUEL = tankUpgrade.getTankCapacity();
+                if (fuelItem.is(ItemsRegistry.FUEL_BUCKET.get()) || fuelItem.is(ItemsRegistry.HYDROGEN_BUCKET.get())) {
+                    inventory.setItem(1, new ItemStack(Items.BUCKET, inventory.getItem(1).getCount() + 1));
+                }
+
+                return true;
             }
-
-            if (inventory.removeItem(0, 1).is(ItemsRegistry.FUEL_BUCKET.get())) {
-                inventory.setItem(1, new ItemStack(Items.BUCKET, inventory.getItem(1).getCount()+1));
-            }
-
-            return true;
         }
 
         return false;
-    }
-
-    private boolean canPutFuelBasedOnCurrentFuelItem(Item item) {
-        if (FUEL == 0) {
-            currentFuelItem = item;
-            return true;
-        }
-
-        return currentFuelItem == item;
     }
 
     @Override
@@ -267,7 +257,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
     }
 
     public void syncRocketData(ServerPlayer player) {
-        this.roverComponent = new RoverComponent(currentFuelItem.toString(), FUEL, motorUpgrade.getFuelType().getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
+        this.roverComponent = new RoverComponent(FUEL_TYPE.getSerializedName(), FUEL, motorUpgrade.getFuelType().getFuelTexture(), tankUpgrade.getTankCapacity(), speedUpgrade.getSpeedModifier());
         if (!level().isClientSide()) {
             NetworkManager.sendToPlayer(player, new SyncRoverComponentPacket(roverComponent));
         }
@@ -305,12 +295,8 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
         compound.put("InventoryCustom", this.inventory.createTag(registryAccess()));
         compound.putInt("fuel", FUEL);
 
-        if (FUEL != 0 && currentFuelItem != null) {
-            if (FuelType.Type.getTypeBasedOnItem(currentFuelItem) != null) {
-                compound.putString("currentFuelItemType", FuelType.Type.getTypeBasedOnItem(currentFuelItem).getSerializedName());
-            } else if (FuelType.Type.Radioactive.getTypeBasedOnItem(currentFuelItem) != null) {
-                compound.putString("currentFuelItemType", FuelType.Type.Radioactive.getTypeBasedOnItem(currentFuelItem).getSerializedName());
-            }
+        if (FUEL != 0) {
+            compound.putString("currentFuelItemType", FUEL_TYPE.getSerializedName());
         }
 
         ListTag listTag = new ListTag();
@@ -335,7 +321,7 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
         FUEL = compound.getInt("fuel");
 
         if (FUEL != 0) {
-            currentFuelItem = FuelType.getItemBasedOnTypeName(compound.getString("currentFuelItemType"));
+            FUEL_TYPE = FuelType.Type.fromString(compound.getString("currentFuelItemType"));
         }
 
         ListTag listTag = compound.getList("Items", 10);

--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/RocketItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/RocketItem.java
@@ -1,10 +1,12 @@
 package com.st0x0ef.stellaris.common.items;
 
+import com.st0x0ef.stellaris.client.renderers.entities.vehicle.rocket.RocketModel;
 import com.st0x0ef.stellaris.common.blocks.RocketLaunchPad;
 import com.st0x0ef.stellaris.common.data_components.RocketComponent;
 import com.st0x0ef.stellaris.common.entities.vehicles.RocketEntity;
 import com.st0x0ef.stellaris.common.registry.DataComponentsRegistry;
 import com.st0x0ef.stellaris.common.registry.EntityRegistry;
+import com.st0x0ef.stellaris.common.vehicle_upgrade.SkinUpgrade;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -107,8 +109,15 @@ public class RocketItem extends Item {
         RocketEntity rocket = new RocketEntity(this.getEntityType(stack), level);
         RocketComponent rocketComponent = stack.get(DataComponentsRegistry.ROCKET_COMPONENT.get());
         if(rocketComponent != null) {
-            rocket.FUEL = rocketComponent.fuel();
-            rocket.FUEL_TYPE = rocketComponent.getFuelType();
+            //Directly setting rocketComponent would give Motor, Tank, Skin and Model upgrades without requiring the item
+            rocket.setRocketComponent(new RocketComponent(
+                    rocket.SKIN_UPGRADE.getRocketSkinLocation().toString(),
+                    RocketModel.fromString(rocket.MODEL_UPGRADE.getModel().toString()),
+                    rocketComponent.fuelType(),
+                    rocketComponent.fuel(),
+                    rocketComponent.getFuelType().getFuelTexture(),
+                    rocket.TANK_UPGRADE.getTankCapacity())
+            );
         }
         return rocket;
     }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/RocketItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/RocketItem.java
@@ -114,7 +114,7 @@ public class RocketItem extends Item {
                     rocket.SKIN_UPGRADE.getRocketSkinLocation().toString(),
                     RocketModel.fromString(rocket.MODEL_UPGRADE.getModel().toString()),
                     rocketComponent.fuelType(),
-                    rocketComponent.fuel(),
+                    Math.max(rocketComponent.fuel(), 0),
                     rocketComponent.getFuelType().getFuelTexture(),
                     rocket.TANK_UPGRADE.getTankCapacity())
             );

--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/RocketItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/RocketItem.java
@@ -151,10 +151,10 @@ public class RocketItem extends Item {
     @Override
     public int getBarColor(ItemStack stack) {
         RocketComponent rocketComponent = stack.get(DataComponentsRegistry.ROCKET_COMPONENT.get());
-        return switch (rocketComponent.getMotorUpgrade().getFuelType()) {
+        return switch (rocketComponent.getFuelType()) {
             case FUEL -> 0xA7E6ED;
             case HYDROGEN -> 0x00d8ff;
-            case RADIOACTIVE -> 0x00c12f;
+            case RADIOACTIVE, URANIUM, NEPTUNIUM, PLUTONIUM -> 0x00c12f;
             case null -> 0xA7E6ED;
 
         };

--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/RocketItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/RocketItem.java
@@ -108,6 +108,7 @@ public class RocketItem extends Item {
         RocketComponent rocketComponent = stack.get(DataComponentsRegistry.ROCKET_COMPONENT.get());
         if(rocketComponent != null) {
             rocket.FUEL = rocketComponent.fuel();
+            rocket.FUEL_TYPE = rocketComponent.getFuelType();
         }
         return rocket;
     }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/RoverItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/RoverItem.java
@@ -58,11 +58,16 @@ public class RoverItem extends Item {
     public RoverEntity getRover(Level level ,ItemStack stack) {
         RoverEntity rover = new RoverEntity(EntityRegistry.ROVER.get(), level);
         RoverComponent roverComponent = stack.get(DataComponentsRegistry.ROVER_COMPONENT.get());
-        if(roverComponent != null) {
-            rover.FUEL = roverComponent.fuel();
-            rover.FUEL_TYPE = roverComponent.getFuelType();
+        if (roverComponent != null) {
+            //Directly setting roverComponent would give Motor, Tank, Skin and Model upgrades without requiring the item
+            rover.setRoverComponent(new RoverComponent(
+                    roverComponent.fuelType(),
+                    roverComponent.fuel(),
+                    roverComponent.getFuelType().getFuelTexture(),
+                    rover.tankUpgrade.getTankCapacity(),
+                    rover.speedUpgrade.getSpeedModifier())
+            );
         }
-
         return rover;
     }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/RoverItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/RoverItem.java
@@ -92,10 +92,10 @@ public class RoverItem extends Item {
     @Override
     public int getBarColor(ItemStack stack) {
         RoverComponent roverComponent = stack.get(DataComponentsRegistry.ROVER_COMPONENT.get());
-        return switch (roverComponent.getMotorUpgrade().getFuelType()) {
+        return switch (roverComponent.getFuelType()) {
             case FUEL -> 0xA7E6ED;
             case HYDROGEN -> 0x00d8ff;
-            case RADIOACTIVE -> 0x00c12f;
+            case RADIOACTIVE, URANIUM, NEPTUNIUM, PLUTONIUM -> 0x00c12f;
             case null -> 0xA7E6ED;
 
         };

--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/RoverItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/RoverItem.java
@@ -60,6 +60,7 @@ public class RoverItem extends Item {
         RoverComponent roverComponent = stack.get(DataComponentsRegistry.ROVER_COMPONENT.get());
         if(roverComponent != null) {
             rover.FUEL = roverComponent.fuel();
+            rover.FUEL_TYPE = roverComponent.getFuelType();
         }
 
         return rover;

--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/RoverItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/RoverItem.java
@@ -62,7 +62,7 @@ public class RoverItem extends Item {
             //Directly setting roverComponent would give Motor, Tank, Skin and Model upgrades without requiring the item
             rover.setRoverComponent(new RoverComponent(
                     roverComponent.fuelType(),
-                    roverComponent.fuel(),
+                    Math.max(roverComponent.fuel(), 0),
                     roverComponent.getFuelType().getFuelTexture(),
                     rover.tankUpgrade.getTankCapacity(),
                     rover.speedUpgrade.getSpeedModifier())

--- a/common/src/main/java/com/st0x0ef/stellaris/common/menus/slot/upgrade/MotorUpgradeSlot.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/menus/slot/upgrade/MotorUpgradeSlot.java
@@ -21,7 +21,7 @@ public class MotorUpgradeSlot extends Slot {
     public boolean mayPlace(ItemStack stack) {
         if (stack.getItem() instanceof VehicleUpgradeItem item) {
             if (item.getUpgrade() instanceof MotorUpgrade motorUpgrade) {
-                return vehicle.getFuel() == 0 || motorUpgrade.getFuelType().acceptsType(vehicle.getFuelType());
+                return vehicle.getFuel() == 0 || motorUpgrade.getFuelType() == vehicle.getFuelType().getMotorType();
             }
         }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/menus/slot/upgrade/MotorUpgradeSlot.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/menus/slot/upgrade/MotorUpgradeSlot.java
@@ -19,8 +19,10 @@ public class MotorUpgradeSlot extends Slot {
 
     @Override
     public boolean mayPlace(ItemStack stack) {
-        if (vehicle.getFuel() == 0 && stack.getItem() instanceof VehicleUpgradeItem item) {
-            return item.getUpgrade() instanceof MotorUpgrade;
+        if (stack.getItem() instanceof VehicleUpgradeItem item) {
+            if (item.getUpgrade() instanceof MotorUpgrade motorUpgrade) {
+                return vehicle.getFuel() == 0 || motorUpgrade.getFuelType().acceptsType(vehicle.getFuelType());
+            }
         }
 
         return false;

--- a/common/src/main/java/com/st0x0ef/stellaris/common/registry/ItemsRegistry.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/registry/ItemsRegistry.java
@@ -344,8 +344,8 @@ public class ItemsRegistry {
 
     public static final RegistrySupplier<Item> BIG_FUEL_TANK_UPGRADE = ITEMS.register("big_fuel_tank_upgrade", () -> new VehicleUpgradeItem(new Item.Properties().arch$tab(CreativeTabsRegistry.STELLARIS_TAB), new TankUpgrade(5000)));
 
-    public static final RegistrySupplier<Item> HYDROGEN_MOTOR_UPGRADE = ITEMS.register("hydrogen_motor", () -> new VehicleUpgradeItem(new Item.Properties().arch$tab(CreativeTabsRegistry.STELLARIS_TAB), new MotorUpgrade(FuelType.Type.HYDROGEN, GUISprites.HYDROGEN_OVERLAY)));
-    public static final RegistrySupplier<Item> RADIOACTIVE_MOTOR_UPGRADE = ITEMS.register("radioactive_motor", () -> new VehicleUpgradeItem(new Item.Properties().arch$tab(CreativeTabsRegistry.STELLARIS_TAB), new MotorUpgrade(FuelType.Type.RADIOACTIVE, GUISprites.ENERGY_FULL)));
+    public static final RegistrySupplier<Item> HYDROGEN_MOTOR_UPGRADE = ITEMS.register("hydrogen_motor", () -> new VehicleUpgradeItem(new Item.Properties().arch$tab(CreativeTabsRegistry.STELLARIS_TAB), new MotorUpgrade(FuelType.Type.HYDROGEN)));
+    public static final RegistrySupplier<Item> RADIOACTIVE_MOTOR_UPGRADE = ITEMS.register("radioactive_motor", () -> new VehicleUpgradeItem(new Item.Properties().arch$tab(CreativeTabsRegistry.STELLARIS_TAB), new MotorUpgrade(FuelType.Type.RADIOACTIVE)));
 
     public static final RegistrySupplier<Item> ROVER = ITEMS.register("rover", () -> new RoverItem(new Item.Properties().arch$tab(CreativeTabsRegistry.STELLARIS_TAB).component(DataComponentsRegistry.ROVER_COMPONENT.get(), new RoverComponent( MotorUpgrade.getBasic().getFuelType().getSerializedName(), 0, GUISprites.FUEL_OVERLAY, TankUpgrade.getBasic().getTankCapacity(), 1))));
     public static final RegistrySupplier<Item> SPEED_UPGRADE = ITEMS.register("speed_upgrade", () -> new VehicleUpgradeItem(new Item.Properties().arch$tab(CreativeTabsRegistry.STELLARIS_TAB), new SpeedUpgrade(1.8f)));

--- a/common/src/main/java/com/st0x0ef/stellaris/common/utils/Utils.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/utils/Utils.java
@@ -17,6 +17,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -79,7 +80,7 @@ public class Utils {
                 }
 
                 if (!serverPlayer.isCreative() && !serverPlayer.isSpectator()) {
-                    int fuelConsumption = Math.round(FuelType.getFuelNeededToGoOnPlanet(PlanetUtil.getPlanet(serverPlayer.level().dimension().location()), destination, fuelType.getItem()));
+                    int fuelConsumption = Math.round(FuelType.getFuelNeededToGoOnPlanet(PlanetUtil.getPlanet(serverPlayer.level().dimension().location()), destination, rocket.FUEL_TYPE));
                     rocket.FUEL -= fuelConsumption;
                     rocket.syncRocketData(serverPlayer);
                 }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/utils/Utils.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/utils/Utils.java
@@ -74,11 +74,6 @@ public class Utils {
                 serverPlayer.stopRiding();
                 serverPlayer.closeContainer();
 
-                ItemStack fuelType = rocket.getInventory().getItem(10);
-                if (fuelType.isEmpty()) {
-                    fuelType = ItemsRegistry.FUEL_BUCKET.get().getDefaultInstance();
-                }
-
                 if (!serverPlayer.isCreative() && !serverPlayer.isSpectator()) {
                     int fuelConsumption = Math.round(FuelType.getFuelNeededToGoOnPlanet(PlanetUtil.getPlanet(serverPlayer.level().dimension().location()), destination, rocket.FUEL_TYPE));
                     rocket.FUEL -= fuelConsumption;

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
@@ -19,7 +19,7 @@ public class FuelType {
             return switch (type) {
                 case FUEL -> 19.22f * fuelQuantity; // Need 20mb to go on Moon, 2133mb to go on Venus, 2900mb to go on Mars and 4786mb to go on Mercury (approx)
                 case HYDROGEN -> 21.36f * fuelQuantity; // Need 18mb to go on Moon, 1920mb to go on Venus, 2610mb to go on Mars and 4307mb to go on Mercury (approx)
-                case URANIUM -> 23.74f * fuelQuantity; // Need 16mb to go on Moon, 1728mb to go on Venus, 2349mb to go on Mars and 3876mb to go on Mercury (approx)
+                case RADIOACTIVE, URANIUM -> 23.74f * fuelQuantity; // Need 16mb to go on Moon, 1728mb to go on Venus, 2349mb to go on Mars and 3876mb to go on Mercury (approx)
                 case NEPTUNIUM -> 26.38f * fuelQuantity; // Need 15mb to go on Moon, 1555mb to go on Venus, 2114mb to go on Mars and 3488mb to go on Mercury (approx)
                 case PLUTONIUM -> 29.3f * fuelQuantity; // Need 14mb to go on Moon, 1400mb to go on Venus, 1903mb to go on Mars and 3140mb to go on Mercury (approx)
                 default -> throw new IllegalStateException("Unexpected value: " + type);
@@ -38,7 +38,7 @@ public class FuelType {
             return switch (type) {
                 case FUEL -> distance / 19.22f; // Need 20mb to go on Moon, 2133mb to go on Venus, 2900mb to go on Mars and 4786mb to go on Mercury (approx)
                 case HYDROGEN -> distance / 21.36f; // Need 18mb to go on Moon, 1920mb to go on Venus, 2610mb to go on Mars and 4307mb to go on Mercury (approx)
-                case URANIUM -> distance / 23.74f; // Need 16mb to go on Moon, 1728mb to go on Venus, 2349mb to go on Mars and 3876mb to go on Mercury (approx)
+                case RADIOACTIVE, URANIUM -> distance / 23.74f; // Need 16mb to go on Moon, 1728mb to go on Venus, 2349mb to go on Mars and 3876mb to go on Mercury (approx)
                 case NEPTUNIUM -> distance / 26.38f; // Need 15mb to go on Moon, 1555mb to go on Venus, 2114mb to go on Mars and 3488mb to go on Mercury (approx)
                 case PLUTONIUM -> distance / 29.3f; // Need 14mb to go on Moon, 1400mb to go on Venus, 1903mb to go on Mars and 3140mb to go on Mercury (approx)
                 default -> throw new IllegalStateException("Unexpected value: " + type);
@@ -73,7 +73,8 @@ public class FuelType {
         HYDROGEN(GUISprites.HYDROGEN_OVERLAY, false),
         URANIUM(GUISprites.ENERGY_FULL, true),
         NEPTUNIUM(GUISprites.ENERGY_FULL, true),
-        PLUTONIUM(GUISprites.ENERGY_FULL, true);
+        PLUTONIUM(GUISprites.ENERGY_FULL, true),
+        RADIOACTIVE(GUISprites.ENERGY_FULL, true);
 
         private final ResourceLocation fuelTexture;
         private final boolean isRadioactive;
@@ -111,6 +112,7 @@ public class FuelType {
                 case "uranium" -> URANIUM;
                 case "neptunium" -> NEPTUNIUM;
                 case "plutonium" -> PLUTONIUM;
+                case "radioactive" -> RADIOACTIVE;
                 default -> null;
             };
         }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
@@ -1,6 +1,7 @@
 package com.st0x0ef.stellaris.common.vehicle_upgrade;
 
 import com.mojang.serialization.Codec;
+import com.st0x0ef.stellaris.client.screens.GUISprites;
 import com.st0x0ef.stellaris.common.data.planets.Planet;
 import com.st0x0ef.stellaris.common.registry.ItemsRegistry;
 import net.minecraft.resources.ResourceLocation;
@@ -103,9 +104,15 @@ public class FuelType {
     }
 
     public enum Type implements StringRepresentable {
-        FUEL,
-        HYDROGEN,
-        RADIOACTIVE;
+        FUEL(GUISprites.FUEL_OVERLAY),
+        HYDROGEN(GUISprites.HYDROGEN_OVERLAY),
+        RADIOACTIVE(GUISprites.ENERGY_FULL);
+
+        private final ResourceLocation fuelTexture;
+
+        private Type(ResourceLocation fuelTexture) {
+            this.fuelTexture = fuelTexture;
+        }
 
         public static Type getTypeBasedOnItem(Item item) {
             if (item == null) return null;
@@ -130,6 +137,10 @@ public class FuelType {
         @Override
         public String getSerializedName() {
             return name().toLowerCase();
+        }
+
+        public ResourceLocation getFuelTexture() {
+            return this.fuelTexture;
         }
 
         public enum Radioactive implements StringRepresentable {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
@@ -117,6 +117,11 @@ public class FuelType {
             };
         }
 
+        public boolean isCompatibleType(Type type) {
+            if (this == type) return true;
+            return this == Type.RADIOACTIVE && type.isRadioactive();
+        }
+
         @Override
         public String getSerializedName() {
             return name().toLowerCase();

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
@@ -117,8 +117,9 @@ public class FuelType {
             };
         }
 
-        public boolean isCompatibleType(Type type) {
+        public boolean acceptsType(Type type) {
             if (this == type) return true;
+            //RADIOACTIVE type can accept other radioactive types, not vice versa
             return this == Type.RADIOACTIVE && type.isRadioactive();
         }
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
@@ -69,23 +69,19 @@ public class FuelType {
     }
 
     public enum Type implements StringRepresentable {
-        FUEL(GUISprites.FUEL_OVERLAY, false),
-        HYDROGEN(GUISprites.HYDROGEN_OVERLAY, false),
-        URANIUM(GUISprites.ENERGY_FULL, true),
-        NEPTUNIUM(GUISprites.ENERGY_FULL, true),
-        PLUTONIUM(GUISprites.ENERGY_FULL, true),
-        RADIOACTIVE(GUISprites.ENERGY_FULL, true);
+        FUEL(GUISprites.FUEL_OVERLAY, null),
+        HYDROGEN(GUISprites.HYDROGEN_OVERLAY, null),
+        RADIOACTIVE(GUISprites.ENERGY_FULL, null),
+        URANIUM(GUISprites.ENERGY_FULL, RADIOACTIVE),
+        NEPTUNIUM(GUISprites.ENERGY_FULL, RADIOACTIVE),
+        PLUTONIUM(GUISprites.ENERGY_FULL, RADIOACTIVE);
 
         private final ResourceLocation fuelTexture;
-        private final boolean isRadioactive;
+        private final Type motorType;
 
-        Type(ResourceLocation fuelTexture, boolean isRadioactive) {
+        Type(ResourceLocation fuelTexture, Type motorType) {
             this.fuelTexture = fuelTexture;
-            this.isRadioactive = isRadioactive;
-        }
-
-        public boolean isRadioactive() {
-            return this.isRadioactive;
+            this.motorType = motorType;
         }
 
         public static Type getTypeBasedOnItem(Item item) {
@@ -117,10 +113,9 @@ public class FuelType {
             };
         }
 
-        public boolean acceptsType(Type type) {
-            if (this == type) return true;
-            //RADIOACTIVE type can accept other radioactive types, not vice versa
-            return this == Type.RADIOACTIVE && type.isRadioactive();
+        public Type getMotorType() {
+            if (this.motorType == null) return this;
+            return this.motorType;
         }
 
         @Override

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
@@ -11,26 +11,18 @@ import net.minecraft.world.item.Item;
 
 public class FuelType {
     public static final Codec<Type> CODEC = StringRepresentable.fromEnum(Type::values);
-    public static final Codec<Type.Radioactive> RADIOACTIVE_CODEC = StringRepresentable.fromEnum(Type.Radioactive::values);
 
     public static float getMegametersTraveled(int fuelQuantity, Item fuelItem) {
         Type type = Type.getTypeBasedOnItem(fuelItem);
 
-        if (type != null && type != Type.RADIOACTIVE) {
+        if (type != null) {
             return switch (type) {
                 case FUEL -> 19.22f * fuelQuantity; // Need 20mb to go on Moon, 2133mb to go on Venus, 2900mb to go on Mars and 4786mb to go on Mercury (approx)
                 case HYDROGEN -> 21.36f * fuelQuantity; // Need 18mb to go on Moon, 1920mb to go on Venus, 2610mb to go on Mars and 4307mb to go on Mercury (approx)
-                default -> throw new IllegalStateException("Unexpected value: " + type);
-            };
-        }
-
-        Type.Radioactive radioactiveElement = Type.Radioactive.getTypeBasedOnItem(fuelItem);
-
-        if (radioactiveElement != null && type == Type.RADIOACTIVE) {
-            return switch (radioactiveElement) {
                 case URANIUM -> 23.74f * fuelQuantity; // Need 16mb to go on Moon, 1728mb to go on Venus, 2349mb to go on Mars and 3876mb to go on Mercury (approx)
                 case NEPTUNIUM -> 26.38f * fuelQuantity; // Need 15mb to go on Moon, 1555mb to go on Venus, 2114mb to go on Mars and 3488mb to go on Mercury (approx)
                 case PLUTONIUM -> 29.3f * fuelQuantity; // Need 14mb to go on Moon, 1400mb to go on Venus, 1903mb to go on Mars and 3140mb to go on Mercury (approx)
+                default -> throw new IllegalStateException("Unexpected value: " + type);
             };
         }
 
@@ -42,45 +34,18 @@ public class FuelType {
 
         Type type = Type.getTypeBasedOnItem(fuelItem);
 
-        if (type != null && type != Type.RADIOACTIVE) {
+        if (type != null) {
             return switch (type) {
                 case FUEL -> distance / 19.22f; // Need 20mb to go on Moon, 2133mb to go on Venus, 2900mb to go on Mars and 4786mb to go on Mercury (approx)
                 case HYDROGEN -> distance / 21.36f; // Need 18mb to go on Moon, 1920mb to go on Venus, 2610mb to go on Mars and 4307mb to go on Mercury (approx)
+                case URANIUM -> distance / 23.74f; // Need 16mb to go on Moon, 1728mb to go on Venus, 2349mb to go on Mars and 3876mb to go on Mercury (approx)
+                case NEPTUNIUM -> distance / 26.38f; // Need 15mb to go on Moon, 1555mb to go on Venus, 2114mb to go on Mars and 3488mb to go on Mercury (approx)
+                case PLUTONIUM -> distance / 29.3f; // Need 14mb to go on Moon, 1400mb to go on Venus, 1903mb to go on Mars and 3140mb to go on Mercury (approx)
                 default -> throw new IllegalStateException("Unexpected value: " + type);
             };
         }
 
-        Type.Radioactive radioactiveElement = Type.Radioactive.getTypeBasedOnItem(fuelItem);
-
-        if (radioactiveElement != null && type == Type.RADIOACTIVE) {
-            return switch (radioactiveElement) {
-                case URANIUM -> distance / 23.74f; // Need 16mb to go on Moon, 1728mb to go on Venus, 2349mb to go on Mars and 3876mb to go on Mercury (approx)
-                case NEPTUNIUM -> distance / 26.38f; // Need 15mb to go on Moon, 1555mb to go on Venus, 2114mb to go on Mars and 3488mb to go on Mercury (approx)
-                case PLUTONIUM -> distance / 29.3f; // Need 14mb to go on Moon, 1400mb to go on Venus, 1903mb to go on Mars and 3140mb to go on Mercury (approx)
-            };
-        }
-
         return 0.0f;
-    }
-
-    public static Item getFuelItem(Type type, Type.Radioactive radioactiveElement) {
-        if (radioactiveElement == null) {
-            return switch (type) {
-                case Type.FUEL -> ItemsRegistry.FUEL_BUCKET.get();
-                case Type.HYDROGEN -> ItemsRegistry.HYDROGEN_BUCKET.get();
-                case RADIOACTIVE -> null;
-            };
-        } else {
-            return switch (type) {
-                case Type.FUEL -> ItemsRegistry.FUEL_BUCKET.get();
-                case Type.HYDROGEN -> ItemsRegistry.HYDROGEN_BUCKET.get();
-                case Type.RADIOACTIVE -> switch (radioactiveElement) {
-                    case Type.Radioactive.URANIUM -> ItemsRegistry.URANIUM_INGOT.get();
-                    case Type.Radioactive.NEPTUNIUM -> ItemsRegistry.NEPTUNIUM_INGOT.get();
-                    case Type.Radioactive.PLUTONIUM -> ItemsRegistry.PLUTONIUM_INGOT.get();
-                };
-            };
-        }
     }
 
     public static Item getItemBasedOnTypeName(String name) {
@@ -88,11 +53,11 @@ public class FuelType {
             return ItemsRegistry.FUEL_BUCKET.get();
         } else if (name.equals(Type.HYDROGEN.getSerializedName())) {
             return ItemsRegistry.HYDROGEN_BUCKET.get();
-        } else if (name.equals(Type.Radioactive.URANIUM.getSerializedName())) {
+        } else if (name.equals(Type.URANIUM.getSerializedName())) {
             return ItemsRegistry.URANIUM_INGOT.get();
-        } else if (name.equals(Type.Radioactive.NEPTUNIUM.getSerializedName())) {
+        } else if (name.equals(Type.NEPTUNIUM.getSerializedName())) {
             return ItemsRegistry.NEPTUNIUM_INGOT.get();
-        } else if (name.equals(Type.Radioactive.PLUTONIUM.getSerializedName())) {
+        } else if (name.equals(Type.PLUTONIUM.getSerializedName())) {
             return ItemsRegistry.PLUTONIUM_INGOT.get();
         }
 
@@ -104,14 +69,22 @@ public class FuelType {
     }
 
     public enum Type implements StringRepresentable {
-        FUEL(GUISprites.FUEL_OVERLAY),
-        HYDROGEN(GUISprites.HYDROGEN_OVERLAY),
-        RADIOACTIVE(GUISprites.ENERGY_FULL);
+        FUEL(GUISprites.FUEL_OVERLAY, false),
+        HYDROGEN(GUISprites.HYDROGEN_OVERLAY, false),
+        URANIUM(GUISprites.ENERGY_FULL, true),
+        NEPTUNIUM(GUISprites.ENERGY_FULL, true),
+        PLUTONIUM(GUISprites.ENERGY_FULL, true);
 
         private final ResourceLocation fuelTexture;
+        private final boolean isRadioactive;
 
-        private Type(ResourceLocation fuelTexture) {
+        Type(ResourceLocation fuelTexture, boolean isRadioactive) {
             this.fuelTexture = fuelTexture;
+            this.isRadioactive = isRadioactive;
+        }
+
+        public boolean isRadioactive() {
+            return this.isRadioactive;
         }
 
         public static Type getTypeBasedOnItem(Item item) {
@@ -120,6 +93,12 @@ public class FuelType {
                 return FUEL;
             } else if (item.getDefaultInstance().is(ItemsRegistry.HYDROGEN_BUCKET.get())) {
                 return HYDROGEN;
+            } else if (item.getDefaultInstance().is(ItemsRegistry.URANIUM_INGOT.get())) {
+                return URANIUM;
+            } else if (item.getDefaultInstance().is(ItemsRegistry.NEPTUNIUM_INGOT.get())) {
+                return NEPTUNIUM;
+            } else if (item.getDefaultInstance().is(ItemsRegistry.PLUTONIUM_INGOT.get())) {
+                return PLUTONIUM;
             }
 
             return null;
@@ -129,7 +108,9 @@ public class FuelType {
             return switch (name) {
                 case "fuel" -> FUEL;
                 case "hydrogen" -> HYDROGEN;
-                case "radioactive" -> RADIOACTIVE;
+                case "uranium" -> URANIUM;
+                case "neptunium" -> NEPTUNIUM;
+                case "plutonium" -> PLUTONIUM;
                 default -> null;
             };
         }
@@ -141,39 +122,6 @@ public class FuelType {
 
         public ResourceLocation getFuelTexture() {
             return this.fuelTexture;
-        }
-
-        public enum Radioactive implements StringRepresentable {
-            URANIUM,
-            NEPTUNIUM,
-            PLUTONIUM;
-
-            public static Radioactive getTypeBasedOnItem(Item item) {
-                if (item == null) return null;
-                if (item.getDefaultInstance().is(ItemsRegistry.URANIUM_INGOT.get())) {
-                    return URANIUM;
-                } else if (item.getDefaultInstance().is(ItemsRegistry.NEPTUNIUM_INGOT.get())) {
-                    return NEPTUNIUM;
-                } else if (item.getDefaultInstance().is(ItemsRegistry.PLUTONIUM_INGOT.get())) {
-                    return PLUTONIUM;
-                }
-
-                return null;
-            }
-
-            public static Radioactive fromString(String name) {
-                return switch (name) {
-                    case "uranium" -> URANIUM;
-                    case "neptunium" -> NEPTUNIUM;
-                    case "plutonium" -> PLUTONIUM;
-                    default -> null;
-                };
-            }
-
-            @Override
-            public String getSerializedName() {
-                return name().toLowerCase();
-            }
         }
     }
 }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/FuelType.java
@@ -12,9 +12,14 @@ import net.minecraft.world.item.Item;
 public class FuelType {
     public static final Codec<Type> CODEC = StringRepresentable.fromEnum(Type::values);
 
+    @Deprecated
     public static float getMegametersTraveled(int fuelQuantity, Item fuelItem) {
         Type type = Type.getTypeBasedOnItem(fuelItem);
 
+        return getMegametersTraveled(fuelQuantity, type);
+    }
+
+    public static float getMegametersTraveled(int fuelQuantity, FuelType.Type type) {
         if (type != null) {
             return switch (type) {
                 case FUEL -> 19.22f * fuelQuantity; // Need 20mb to go on Moon, 2133mb to go on Venus, 2900mb to go on Mars and 4786mb to go on Mercury (approx)
@@ -29,10 +34,15 @@ public class FuelType {
         return 0.0f;
     }
 
+    @Deprecated
     public static float getFuelNeededToGoOnPlanet(Planet actual, Planet destination, Item fuelItem) {
-        float distance = Mth.abs(actual.distanceFromEarth() - destination.distanceFromEarth());
-
         Type type = Type.getTypeBasedOnItem(fuelItem);
+
+        return getFuelNeededToGoOnPlanet(actual, destination, type);
+    }
+
+    public static float getFuelNeededToGoOnPlanet(Planet actual, Planet destination, Type type) {
+        float distance = Mth.abs(actual.distanceFromEarth() - destination.distanceFromEarth());
 
         if (type != null) {
             return switch (type) {
@@ -47,6 +57,7 @@ public class FuelType {
 
         return 0.0f;
     }
+
 
     public static Item getItemBasedOnTypeName(String name) {
         if (name.equals(Type.FUEL.getSerializedName())) {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/MotorUpgrade.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/MotorUpgrade.java
@@ -5,11 +5,9 @@ import net.minecraft.resources.ResourceLocation;
 
 public class MotorUpgrade extends VehicleUpgrade {
     private final FuelType.Type type;
-    private final ResourceLocation fluidTexture;
 
-    public MotorUpgrade(FuelType.Type type, ResourceLocation fluidTexture) {
+    public MotorUpgrade(FuelType.Type type) {
         this.type = type;
-        this.fluidTexture = fluidTexture;
     }
 
     public FuelType.Type getFuelType() {
@@ -18,11 +16,8 @@ public class MotorUpgrade extends VehicleUpgrade {
         }
         return this.type;
     }
-    public ResourceLocation getFluidTexture() {
-        return this.fluidTexture;
-    }
 
     public static MotorUpgrade getBasic() {
-        return new MotorUpgrade(FuelType.Type.FUEL, GUISprites.FUEL_OVERLAY);
+        return new MotorUpgrade(FuelType.Type.FUEL);
     }
 }

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/MotorUpgrade.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/MotorUpgrade.java
@@ -10,6 +10,11 @@ public class MotorUpgrade extends VehicleUpgrade {
         this.type = type;
     }
 
+    @Deprecated
+    public MotorUpgrade(FuelType.Type type, ResourceLocation fluidTexture) {
+        this(type);
+    }
+
     public FuelType.Type getFuelType() {
         if (this.type == null) {
             return getBasic().getFuelType();

--- a/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/MotorUpgrade.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/vehicle_upgrade/MotorUpgrade.java
@@ -17,6 +17,11 @@ public class MotorUpgrade extends VehicleUpgrade {
         return this.type;
     }
 
+    @Deprecated
+    public ResourceLocation getFluidTexture() {
+        return this.getFuelType().getFuelTexture();
+    }
+
     public static MotorUpgrade getBasic() {
         return new MotorUpgrade(FuelType.Type.FUEL);
     }


### PR DESCRIPTION
Bugs fixed (worded as the previous behaviour)

- Rocket stops being Hydrogen/Radioactive once broken, saved and loaded, or taken to another planet
- Hydrogen/Radioactive fuels are not more efficient than Fuel
- Fuel required, and fuel consumed, are calculated differently
- Rocket can go negative and allows you to go to planets without enough fuel
- Motor can not be put back in the rocket 
- Buckets are deleted when fuelling with Hydrogen
- Adding fuel can lower the amount of fuel if a big tank was removed
- Rocket component stores the item in some cases, and the fuel type in other cases

It also fixes old items made in the previous versions with broken data where possible, allowing them to be converted back instead of requiring the player to delete them and remake it.


This does do some strange things which are not the ideal way to deal with it, but are the best way to do it without making major changes to code I did not write:

- Uranium, Plutonium and Neptunium are added as fuel types in their own right
- FuelType.Type.Radioactive is removed, and the behaviour is implemented into FuelType.Type instead.
- Fuel types can have a separate "Motor Type" (for Uranium, Plutonium and Neptunium, this is Radioactive)
- Where possible, I kept public methods, and made them function as expected, but marked as deprecated.
- The fuel overlay texture is now tied to the Fuel Type, not the Motor Upgrade
- Fuel overlay texture is serialised in Rocket Component, but never used - removing this variable would break the component format and previously made items.


I have tested saving, loading, breaking, placing, using and landing rockets and rovers and they have worked as they should in all cases.