### PR TITLE
Fix final can in a stack being deleted when consumed

### DIFF
--- a/common/src/main/java/com/st0x0ef/stellaris/common/items/CanItem.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/items/CanItem.java
@@ -77,9 +77,9 @@ public class CanItem extends Item {
 
     @Override
     public @NotNull ItemStack finishUsingItem(ItemStack stack, Level level, LivingEntity entity) {
+        ItemStack emptyCanStack = new ItemStack(stack.getItem());
         super.finishUsingItem(stack, level, entity);
         if (entity instanceof Player player && !player.hasInfiniteMaterials()) {
-            ItemStack emptyCanStack = new ItemStack(stack.getItem());
             if (stack.isEmpty()) {
                 return emptyCanStack;
             }


### PR DESCRIPTION
Fixes a simple bug where the empty can stack is constructed using the full can stack _after_ the full can stack no longer exists. This only applies to stacks with one can left, where there is more than one in a stack it would work except for the last one.

It is a one line (only moved, no changes) fix so I would not normally PR this but it does not fit with the scope of my other PRs at all 