### PR TITLE
Fix possible NPE from previous PR

### DIFF
--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -515,6 +515,8 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
         }
 
         FuelType.Type itemType = FuelType.Type.getTypeBasedOnItem(item);
+        if (itemType == null) return false;
+
         FuelType.Type motorType = MOTOR_UPGRADE.getFuelType();
 
         if (motorType == itemType.getMotorType()) {

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RoverEntity.java
@@ -202,6 +202,8 @@ public class RoverEntity extends AbstractRoverBase implements HasCustomInventory
         }
 
         FuelType.Type itemType = FuelType.Type.getTypeBasedOnItem(item);
+        if (itemType == null) return false;
+
         FuelType.Type motorType = motorUpgrade.getFuelType();
 
         if (motorType == itemType.getMotorType()) {


### PR DESCRIPTION
Found an issue in my previous PR that somehow did not come up during extensive testing.

Put the patches on my main server and immediately crashed due to NPE with empty rovers... strangely not in my test server (which has entities from before patches as well) - but this will fix it and prevent it happening again.