### PR TITLE
Retain fuel type and passengers when changing model

### DIFF
--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -632,6 +632,10 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
 
         newRocketEntity.setRocketComponent(this.rocketComponent);
 
+        newRocketEntity.MODEL_UPGRADE = this.MODEL_UPGRADE;
+
+        newRocketEntity.needsModelChange = this.needsModelChange;
+
         newRocketEntity.setModelData();
         newRocketEntity.setSkinData();
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -627,14 +627,13 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
         RocketEntity newRocketEntity = new RocketEntity(newRocketType, this.level());
         newRocketEntity.setPos(pos);
         newRocketEntity.setYRot(this.getYRot());
-        newRocketEntity.MODEL_UPGRADE = this.MODEL_UPGRADE;
         newRocketEntity.setModelData();
-        newRocketEntity.SKIN_UPGRADE = this.SKIN_UPGRADE;
         newRocketEntity.setSkinData();
-        newRocketEntity.MOTOR_UPGRADE = this.MOTOR_UPGRADE;
-        newRocketEntity.TANK_UPGRADE = this.TANK_UPGRADE;
-        newRocketEntity.FUEL = this.FUEL;
-        newRocketEntity.needsModelChange = this.needsModelChange;
+
+        newRocketEntity.setRocketComponent(this.rocketComponent);
+
+        newRocketEntity.setModelData();
+        newRocketEntity.setSkinData();
 
         for (int i = 0; i < inventory.getContainerSize(); i++) newRocketEntity.inventory.setItem(i, itemStacks.get(i));
 

--- a/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/entities/vehicles/RocketEntity.java
@@ -637,9 +637,10 @@ public class RocketEntity extends IVehicleEntity implements HasCustomInventorySc
 
         for (int i = 0; i < inventory.getContainerSize(); i++) newRocketEntity.inventory.setItem(i, itemStacks.get(i));
 
+        List<Entity> passengers = getPassengers();
         this.remove(RemovalReason.DISCARDED);
         newRocketEntity.level().addFreshEntity(newRocketEntity);
-        for (Entity passenger : getPassengers()) passenger.startRiding(newRocketEntity);
+        for (Entity passenger : passengers) passenger.startRiding(newRocketEntity);
         newRocketEntity.openCustomInventoryScreen(lastPlayer);
     }
 


### PR DESCRIPTION
Fixes two problems:

- Passengers are dropped when model is changed
- Fuel Type can reset to Fuel when model is changed

The second part was missed by my previous PR but has been tested both on test and main server with this change 👍 

The first part is an unrelated issue that I noticed while adding this support, so I included it

Apologies for another PR, this should have been included in the original Rovers and Rockets change but I missed this.