### PR TITLE
Fix crash on disconnect + add to statistics screen

### DIFF
--- a/common/src/main/java/com/st0x0ef/stellaris/common/registry/StatsRegistry.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/registry/StatsRegistry.java
@@ -6,7 +6,6 @@ import dev.architectury.registry.registries.RegistrySupplier;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.stats.StatFormatter;
-import net.minecraft.stats.Stats;
 
 public class StatsRegistry {
 
@@ -14,8 +13,8 @@ public class StatsRegistry {
 
     public static StatFormatter KILOMETERS = (value) -> value + " km";
 
-    public static RegistrySupplier<ResourceLocation> SPACE_TRAVEL = STATS.register("space_traveled", () -> Stats.makeCustomStat("space_traveled", KILOMETERS));
-    public static RegistrySupplier<ResourceLocation> ROCKET_LAUNCHED = STATS.register("rocket_launched", () -> Stats.makeCustomStat("rocket_launched", StatFormatter.DEFAULT));
+    public static RegistrySupplier<ResourceLocation> SPACE_TRAVEL = STATS.register("space_traveled", () -> ResourceLocation.fromNamespaceAndPath(Stellaris.MODID, "space_traveled"));
+    public static RegistrySupplier<ResourceLocation> ROCKET_LAUNCHED = STATS.register("rocket_launched", () -> ResourceLocation.fromNamespaceAndPath(Stellaris.MODID, "rocket_launched"));
 
     public static void init() {
         STATS.register();

--- a/common/src/main/java/com/st0x0ef/stellaris/common/registry/StatsRegistry.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/registry/StatsRegistry.java
@@ -6,6 +6,7 @@ import dev.architectury.registry.registries.RegistrySupplier;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.stats.StatFormatter;
+import net.minecraft.stats.Stats;
 
 public class StatsRegistry {
 
@@ -18,5 +19,8 @@ public class StatsRegistry {
 
     public static void init() {
         STATS.register();
+
+        Stats.CUSTOM.get(ROCKET_LAUNCHED.get());
+        Stats.CUSTOM.get(SPACE_TRAVEL.get(), KILOMETERS);
     }
 }

--- a/common/src/main/resources/assets/stellaris/lang/en_us.json
+++ b/common/src/main/resources/assets/stellaris/lang/en_us.json
@@ -607,6 +607,9 @@
   "stellaris.screen.tablet.space_traveled": "Kilometers Traveled : %s",
   "stellaris.screen.tablet.boss_killed": "Boss Killed : %s",
 
+  "stat.stellaris.rocket_launched": "Rockets Launched",
+  "stat.stellaris.space_traveled": "Space Traveled",
+
   "translatable.stellaris.registry.holdshift": "Hold [↑ Shift] to view more info.",
   "translatable.stellaris.registry.player": "Player",
   "translatable.stellaris.registry.players": "Player",


### PR DESCRIPTION
Fixes this crash when disconnecting from a server with Stellaris 1.3.0+ (exact trace may vary but cause is the same):

`Description: mouseClicked event handler

java.lang.NullPointerException: mouseClicked event handler
	at knot//com.google.common.collect.Iterators$6.transform(Iterators.java:829)
	at knot//com.google.common.collect.TransformedIterator.next(TransformedIterator.java:52)
	at knot//net.minecraft.class_2370.remap(class_2370.java:2247)
	at knot//net.minecraft.class_2370.unmap(class_2370.java:2378)
	at knot//net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager.unmap(RegistrySyncManager.java:367)`


Additionally adds the statistics to the menu "Statistics" screen using the defined Kilometers formatter, and adds a translation key for this.