### PR TITLE
[Feat] Cultures Rework

### DIFF
--- a/common/src/main/java/com/st0x0ef/stellaris/common/registry/TagRegistry.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/registry/TagRegistry.java
@@ -48,4 +48,6 @@ public class TagRegistry {
     public static final TagKey<Block> ENERGY_BLOCK_TAG = TagKey.create(Registries.BLOCK, id("energy_block"));
     public static final TagKey<MobEffect> RADIOACTIVEEFFECT = TagKey.create(Registries.MOB_EFFECT, id("radioactive"));
     public static final TagKey<Block> INCORRECT_FOR_STEEL_TOOL = TagKey.create(Registries.BLOCK, id("incorrect_for_steel_tools"));
+    public static final TagKey<Block> ALIEN_CROPS = TagKey.create(Registries.BLOCK, id("alien_crops"));
+
 }

--- a/common/src/main/java/com/st0x0ef/stellaris/mixin/CropGrowsMixin.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/mixin/CropGrowsMixin.java
@@ -1,0 +1,52 @@
+package com.st0x0ef.stellaris.mixin;
+
+import com.st0x0ef.stellaris.common.data.planets.Planet;
+import com.st0x0ef.stellaris.common.oxygen.GlobalOxygenManager;
+import com.st0x0ef.stellaris.common.registry.TagRegistry;
+import com.st0x0ef.stellaris.common.utils.PlanetUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.CropBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(CropBlock.class)
+public class CropGrowsMixin {
+
+    /**
+     * Cancels crop growth if the planet does not have oxygen and the crop is not tagged as alien crops.
+     * This is to prevent crops from growing in environments without oxygen.
+     */
+    @Inject(method = "randomTick", at = @At("HEAD"), cancellable = true)
+    private void cancelCropGrowth(BlockState state, ServerLevel level, BlockPos pos, RandomSource random, CallbackInfo ci) {
+        boolean hasOxygen = GlobalOxygenManager.getInstance().getOrCreateDimensionManager(level).hasOxygenAt(pos);
+        Planet planet = PlanetUtil.getPlanet(level.dimension().location());
+
+        if(planet != null && !planet.oxygen() && !state.is(TagRegistry.ALIEN_CROPS) && !hasOxygen) {
+            ci.cancel();
+        }
+    }
+
+    /**
+     * Cancels crop placement if the planet does not have oxygen and the crop is not tagged as alien crops.
+     * This is to prevent crops from being placed in environments without oxygen.
+     */
+    @Inject(method = "mayPlaceOn", at = @At("HEAD"), cancellable = true)
+    private void cancelCropPlacement(BlockState state, BlockGetter level, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+
+        if(level instanceof ServerLevel serverLevel) {
+            boolean hasOxygen = GlobalOxygenManager.getInstance().getOrCreateDimensionManager(serverLevel).hasOxygenAt(pos);
+            Planet planet = PlanetUtil.getPlanet(serverLevel.dimension().location());
+
+            if(planet != null && !planet.oxygen() && !state.is(TagRegistry.ALIEN_CROPS) && !hasOxygen) {
+                cir.setReturnValue(false);
+            }
+        }
+    }
+}

--- a/common/src/main/resources/data/stellaris/tags/block/alien_crops.json
+++ b/common/src/main/resources/data/stellaris/tags/block/alien_crops.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "stellaris:mars_crop",
+    "stellaris:moon_crop"
+  ]
+}

--- a/common/src/main/resources/stellaris-common.mixins.json
+++ b/common/src/main/resources/stellaris-common.mixins.json
@@ -8,6 +8,7 @@
     "CandleBlockMixin",
     "ChunkAccessMixin",
     "ChunkSerializerMixin",
+    "CropGrowsMixin",
     "EntityFallMixin",
     "ItemEntityMixin",
     "LivingEntityMixin",


### PR DESCRIPTION
This PR change a bit how function crops in space.
There will be two types of crops : Alien Crops and Basic Crops.

- Basic crops are all minecraft crops. They can"t be planted on a planet unless it has oxygen. Player will need to oxygenate their farms to be able to plant crops.

- Alien Crops are crops that require (for the moment, can be changed) a specific block for it to be placed. For exemple, Moon Fruits can only be placed on moon sand. Theses crops don't need oxygen.

