### PR TITLE
Fix crash when chunkOilChance is set to 0

### DIFF
--- a/common/src/main/java/com/st0x0ef/stellaris/common/oil/OilUtils.java
+++ b/common/src/main/java/com/st0x0ef/stellaris/common/oil/OilUtils.java
@@ -8,10 +8,13 @@ import java.util.Random;
 public class OilUtils {
 
     public static int getRandomOilLevel() {
+        int chance = Stellaris.CONFIG.oilConfig.chunkOilChance;
+        if (chance <= 0) {
+            return 0;
+        }
         Random random = new Random();
-        if (random.nextInt(0, Stellaris.CONFIG.oilConfig.chunkOilChance) == 0) {
+        if (random.nextInt(0, chance) == 0) {
             return random.nextInt(Stellaris.CONFIG.oilConfig.minOil, Stellaris.CONFIG.oilConfig.maxOil) * 1000;
-
         }
         return 0;
     }


### PR DESCRIPTION
## Summary

- `OilUtils.getRandomOilLevel()` calls `Random.nextInt(0, chunkOilChance)`, which throws `IllegalArgumentException` when `chunkOilChance` is `0` (bound must be > origin)
- This crashes chunk serialization on both read and write paths, corrupting world saves
- Added a guard clause: when `chunkOilChance <= 0`, return `0` immediately (no oil), respecting the user's config intent

## Test Plan

- [x] Set `chunkOilChance` to `0` in `stellaris-config.json`
- [x] Created new world, generated chunks in Overworld — no crash
- [x] Teleported to Nether, generated new chunks — no crash
- [x] Teleported to The End, generated new chunks — no crash
- [x] Visited Mercury, Venus, Mars — all generated chunks without crash
- [x] Saved and re-entered world successfully

Fixes #194